### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ categories = ["encoding"]
 license = "MIT"
 
 [features]
+default = ["std"]
 # Only for CI to make all warnings errors, do not activate otherwise (may break forward compatibility)
 strict = []
+std = []
 
 [dependencies]
 bech32 = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 default = ["std"]
 # Only for CI to make all warnings errors, do not activate otherwise (may break forward compatibility)
 strict = []
-std = []
+std = ["bech32/std"]
 
 [dependencies]
-bech32 = "0.8.0"
+bech32 = { version = "0.8.0", default-features = false }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,6 +23,8 @@
 //! The authoratative list of Human-readable parts for Bech32 addresses is
 //! maintained in [SLIP-0173](https://github.com/satoshilabs/slips/blob/master/slip-0173.md).
 
+use crate::imports::*;
+
 /// The cryptocurrency to act on
 #[derive(PartialEq, Eq, Debug, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum Network {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,14 +59,32 @@
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), macro_use)]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+pub(crate) mod imports {
+    pub use alloc::string::String;
+    pub use alloc::string::ToString;
+    pub use alloc::vec::Vec;
+    pub use core::fmt;
+    pub use core::str::FromStr;
+}
+#[cfg(feature = "std")]
+pub(crate) mod imports {
+    pub use std::str::FromStr;
+    pub use std::string::ToString;
+    pub use std::{error, fmt};
+}
+
+use imports::*;
 
 extern crate bech32;
 pub use bech32::u5;
 use bech32::{decode, encode, FromBase32, ToBase32, Variant};
-
-use std::str::FromStr;
-use std::string::ToString;
-use std::{error, fmt};
 
 pub mod constants;
 use constants::Network;
@@ -296,6 +314,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {


### PR DESCRIPTION
Adds a feature `std`, enabled by default, which enables using the standard library. In `no_std` the only functionality we lose is the `Error` trait impl.